### PR TITLE
Make Failed Zip Code Queries Survivable

### DIFF
--- a/lib/census.js
+++ b/lib/census.js
@@ -1002,28 +1002,33 @@ CensusModule.prototype.addressToFIPS = function(street, city, state, callback) {
  * @param callback
  */
 CensusModule.prototype.ZIPtoLatLng = function(zip, callback) {
-    var zipPattern = /({zip})/;
+  var zipPattern = /({zip})/;
 
-    var tigerURL = "http://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/2/query?where=ZCTA5%3D{zip}&text=&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&relationParam=&outFields=CENTLAT%2CCENTLON&returnGeometry=false&maxAllowableOffset=&geometryPrecision=&outSR=&returnIdsOnly=false&returnCountOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&gdbVersion=&returnDistinctValues=false&f=pjson";
+  var tigerURL = "http://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/2/query?where=ZCTA5%3D{zip}&text=&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&relationParam=&outFields=CENTLAT%2CCENTLON&returnGeometry=false&maxAllowableOffset=&geometryPrecision=&outSR=&returnIdsOnly=false&returnCountOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&gdbVersion=&returnDistinctValues=false&f=pjson";
 
-    tigerURL = tigerURL.replace(zipPattern, zip);
+  tigerURL = tigerURL.replace(zipPattern, zip);
 
-    var request = utils.ajaxRequest(tigerURL, function(response) {
-        response = JSON.parse(response);
-        var returnValue = {
-            "lat": null,
-            "lng": null
-        };
-
-        if("features" in response) {
-            if(response.features.length > 0) {
-                returnValue.lat = response.features[0].attributes.CENTLAT;
-                returnValue.lng = response.features[0].attributes.CENTLON;
-            }
+  var request = utils.ajaxRequest(tigerURL, function(response) {
+    var returnValue = {
+      "lat": null,
+      "lng": null
+    };
+    
+    try {
+      response = JSON.parse(response);
+      
+      if("features" in response) {
+        if(response.features.length > 0) {
+          returnValue.lat = response.features[0].attributes.CENTLAT;
+          returnValue.lng = response.features[0].attributes.CENTLON;
         }
+      }        
+    } catch (e) {
+      response = response;
+    }
 
-        callback(returnValue);
-    });
+    callback(returnValue);
+  });
 };
 
 
@@ -1260,9 +1265,13 @@ CensusModule.prototype.tigerwebRequest = function(request, callback) {
         if(!("lat" in request) || !("lng" in request)) {
             //We have the zip but no lat/lng - parse it and re-call
             this.ZIPtoLatLng(request.zip, function(response) {
-                request.lat = response.lat;
-                request.lng = response.lng;
-                _this.tigerwebRequest(request, callback);
+                request.lat = response.lat === null ? 0 : response.lat;
+                request.lng = response.lng === null ? 0 : response.lng;
+                if(!request.lat && !request.lng) {
+                  request.data = []
+                  callback(request);
+                } else
+                  _this.APIRequest(request, callback);
                 return;
             });
         }
@@ -1493,9 +1502,13 @@ CensusModule.prototype.APIRequest = function(request, callback) {
         if(!("lat" in request) || !("lng" in request)) {
             //We have the zip but no lat/lng - parse it and re-call
             this.ZIPtoLatLng(request.zip, function(response) {
-                request.lat = response.lat;
-                request.lng = response.lng;
-                _this.APIRequest(request, callback);
+                request.lat = response.lat === null ? 0 : response.lat;
+                request.lng = response.lng === null ? 0 : response.lng;
+                if(!request.lat && !request.lng) {
+                  request.data = []
+                  callback(request);
+                } else
+                  _this.APIRequest(request, callback);
                 return;
             });
         }
@@ -1682,7 +1695,10 @@ CensusModule.prototype.GEORequest = function(request, callback) {
     //First - check if we have a data object in the request OR if we aren't requesting variables
     if("data" in request || !("variables" in request)) {
         //We have a data object for the request (or there isn't any requested), now we can get the geoJSON for the area
-        _this.tigerwebRequest(request, function(response) {
+        if(!request.lat && !request.lng) {
+          callback('error code');
+        } else {
+          _this.tigerwebRequest(request, function(response) {
             if(!("totals" in response)) {
                 response.totals = {};
             }
@@ -1752,6 +1768,7 @@ CensusModule.prototype.GEORequest = function(request, callback) {
             }
             callback(response);
         });
+        }
     } else {
         //We do not have the requested variables - let's get them
         _this.APIRequest(request, function(response) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,14 +10,19 @@ module.exports = {
     },
 
     jsonpRequest: function(url, callback) {
-        var opts = { 
-            url: url,
-            method: "GET"
-        };
+      var opts = { 
+          url: url,
+          method: "GET"
+      };
 
-        request(opts, function(error, response, body) {
-            return callback(JSON.parse(body));
-        });
+      request(opts, function(error, response, body) {
+        try {
+          response = JSON.parse(body);
+          callback(response);        
+        } catch (e) {
+          callback(error);
+        }
+      });
     },
 
     postRequest: function(url, data, callback) {


### PR DESCRIPTION
Currently the package blows up when there is a failure point. This helps make failed queries for zip codes survivable and would keep a node service running, returning an error code instead of throwing a breaking error.
